### PR TITLE
Remove timestamps from BehaviorTimeSeries

### DIFF
--- a/element_event/trial.py
+++ b/element_event/trial.py
@@ -227,7 +227,6 @@ class BehaviorTimeSeries(dj.Imported):
         -> master
         -> Trial
         ---
-        behavior_timestamps     : longblob  # array of timestamps (in second) relative to the start of the BehaviorRecording  
         behavior_timeseries     : longblob  # array of device's acquired data
         """
 

--- a/element_event/trial.py
+++ b/element_event/trial.py
@@ -227,7 +227,8 @@ class BehaviorTimeSeries(dj.Imported):
         -> master
         -> Trial
         ---
-        behavior_timeseries     : longblob  # array of device's acquired data
+        behavior_timestamps=null     : longblob  # array of timestamps (in second) relative to the start of the BehaviorRecording  
+        behavior_timeseries          : longblob  # array of device's acquired data
         """
 
     def make(self, key):


### PR DESCRIPTION
- Remove `timestamps` from `BehaviorTimeSeries` table.
- timeseries name of `TrialTime` will be the timestamp for each trace.